### PR TITLE
Put classes after macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,9 @@ add_compile_definitions(NEED_UNSAFE_CSHARP)
 add_compile_definitions(UNITY_2021)
 add_compile_definitions(NO_VERBOSE_LOGS)
 # For performing debug logging of very hard to diagnose issues
-add_compile_definitions(CT_USE_GCDESCRIPTOR_DEBUG)
+if (NOT DEFINED LOCAL_TEST)
+    add_compile_definitions(CT_USE_GCDESCRIPTOR_DEBUG)
+endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 

--- a/qpm.json
+++ b/qpm.json
@@ -5,7 +5,7 @@
   "info": {
     "name": "custom-types",
     "id": "custom-types",
-    "version": "0.16.0",
+    "version": "0.18.0",
     "url": "https://github.com/QuestPackageManager/Il2CppQuestTypePatching",
     "additionalData": {
       "overrideSoName": "libcustom-types.so",
@@ -20,6 +20,7 @@
   "workspace": {
     "scripts": {
       "build": ["pwsh ./build.ps1"],
+      "test": ["pwsh ./build.ps1 -local_test"],
       "qmod": [
         "pwsh ./build.ps1 -clean",
         "qpm qmod manifest",

--- a/qpm.shared.json
+++ b/qpm.shared.json
@@ -6,7 +6,7 @@
     "info": {
       "name": "custom-types",
       "id": "custom-types",
-      "version": "0.16.0",
+      "version": "0.18.0",
       "url": "https://github.com/QuestPackageManager/Il2CppQuestTypePatching",
       "additionalData": {
         "overrideSoName": "libcustom-types.so",
@@ -27,6 +27,9 @@
           "pwsh ./build.ps1 -clean",
           "qpm qmod manifest",
           "pwsh ./createqmod.ps1 CustomTypes -clean"
+        ],
+        "test": [
+          "pwsh ./build.ps1 -local_test"
         ]
       },
       "qmodIncludeDirs": [

--- a/shared/coroutine.hpp
+++ b/shared/coroutine.hpp
@@ -206,8 +206,7 @@ namespace custom_types::Helpers {
     }
 }
 
-DECLARE_CLASS_INTERFACES(custom_types::Helpers, ResetableCoroutine, "System", "Object", sizeof(Il2CppObject),
-        (il2cpp_utils::GetClassFromName("System.Collections", "IEnumerator")),
+DECLARE_CLASS_INTERFACES(custom_types::Helpers, ResetableCoroutine, "System", "Object", sizeof(Il2CppObject), INTERFACE_NAME("System.Collections", "IEnumerator")) {
     private:
     custom_types::Helpers::CoroFuncType coroCreator;
     custom_types::Helpers::Wrapper current;
@@ -220,10 +219,9 @@ DECLARE_CLASS_INTERFACES(custom_types::Helpers, ResetableCoroutine, "System", "O
     DECLARE_OVERRIDE_METHOD(Il2CppObject*, get_Current, il2cpp_utils::FindMethod("System.Collections", "IEnumerator", "get_Current"));
     DECLARE_OVERRIDE_METHOD(void, Reset, il2cpp_utils::FindMethod("System.Collections", "IEnumerator", "Reset"));
     DECLARE_DTOR(Finalize);
-)
+};
 
-DECLARE_CLASS_INTERFACES(custom_types::Helpers, StandardCoroutine, "System", "Object", sizeof(Il2CppObject),
-        (il2cpp_utils::GetClassFromName("System.Collections", "IEnumerator")),
+DECLARE_CLASS_INTERFACES(custom_types::Helpers, StandardCoroutine, "System", "Object", sizeof(Il2CppObject), INTERFACE_NAME("System.Collections", "IEnumerator")) {
     struct CoroutineNotResettable : std::runtime_error {
         CoroutineNotResettable() : std::runtime_error("StandardCoroutine is not resettable!") {}
     };
@@ -238,7 +236,7 @@ DECLARE_CLASS_INTERFACES(custom_types::Helpers, StandardCoroutine, "System", "Ob
     DECLARE_OVERRIDE_METHOD(Il2CppObject*, get_Current, il2cpp_utils::FindMethod("System.Collections", "IEnumerator", "get_Current"));
     DECLARE_OVERRIDE_METHOD(void, Reset, il2cpp_utils::FindMethod("System.Collections", "IEnumerator", "Reset"));
     DECLARE_DTOR(Finalize);
-)
+};
 
 namespace custom_types::Helpers {
     /// @brief Represents an allocation failure when creating a new coroutine.

--- a/shared/macro-types.hpp
+++ b/shared/macro-types.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include "register.hpp"
+#include "util.hpp"
+#include "beatsaber-hook/shared/utils/il2cpp-utils.hpp"
+
+namespace custom_types {
+    template<typename T, typename R, Il2CppTypeEnum typeEnum_, size_t baseSize>
+    struct TypeWrapperParent {
+        using ___TargetType = T;
+        using ___TypeRegistration = R;
+        constexpr static auto ___Base__Size = baseSize;
+        constexpr static bool __IL2CPP_IS_VALUE_TYPE = typeEnum_ != Il2CppTypeEnum::IL2CPP_TYPE_CLASS;
+        static inline constexpr const int __IL2CPP_REFERENCE_TYPE_SIZE = sizeof(T);
+        uint8_t _baseFields[baseSize];
+        TypeWrapperParent(TypeWrapperParent&&) = delete;
+        TypeWrapperParent(TypeWrapperParent const&) = delete;
+        protected:
+        TypeWrapperParent() {};
+    };
+
+    template<typename T, typename R, Il2CppTypeEnum typeEnum_, typename baseT>
+    struct TypeWrapperInheritanceParent : public baseT {
+        using ___TargetType = T;
+        using ___TypeRegistration = R;
+        constexpr static auto ___Base__Size = sizeof(baseT);
+        constexpr static bool __IL2CPP_IS_VALUE_TYPE = typeEnum_ != Il2CppTypeEnum::IL2CPP_TYPE_CLASS;
+        static inline constexpr const int __IL2CPP_REFERENCE_TYPE_SIZE = sizeof(T);
+        TypeWrapperInheritanceParent(TypeWrapperInheritanceParent&&) = delete;
+        TypeWrapperInheritanceParent(TypeWrapperInheritanceParent const&) = delete;
+        protected:
+        TypeWrapperInheritanceParent() {};
+    };
+}

--- a/shared/macros.hpp
+++ b/shared/macros.hpp
@@ -5,6 +5,7 @@
 #include <stddef.h>
 #include <new>
 #include <utility>
+#include "macro-types.hpp"
 #include "util.hpp"
 #include "beatsaber-hook/shared/utils/utils.h"
 #include "beatsaber-hook/shared/utils/il2cpp-utils.hpp"
@@ -51,8 +52,8 @@
 #error "___DECLARE_TYPE_WRAPPER_INHERITANCE is already defined! Undefine it before including macros.hpp!"
 #endif
 
-#ifndef INTERFACE_LIST
-#define INTERFACE_LIST(...) ::custom_types::ExtractClasses<__VA_ARGS__>()
+#ifndef INTERFACE_NAME
+#define INTERFACE_NAME(namespaze_, name_) ::custom_types::interface_helper<namespaze_, name_>
 #endif
 
 #ifndef CUSTOM_TYPES_EXPORT_VISIBILITY
@@ -60,21 +61,12 @@
 #endif
 
 // Helper macro for declaring classes with and without interfaces
-#define ___DECLARE_TYPE_WRAPPER(namespaze_, name_, typeEnum_, baseNamespaze, baseName, baseSize, dllName_, interfaces_, flags_, ...) \
+#define ___DECLARE_TYPE_WRAPPER(namespaze_, name_, typeEnum_, baseNamespaze, baseName, baseSize, dllName_, flags_, ...) \
 namespace namespaze_ { \
     class name_; \
-} \
-MARK_REF_PTR_T(namespaze_::name_);\
-namespace namespaze_ { \
-    class CUSTOM_TYPES_EXPORT_VISIBILITY name_ { \
-        using ___TargetType = name_; \
-        constexpr static auto ___Base__Size = baseSize; \
-        friend ::custom_types::Register; \
-        public: \
-        constexpr static bool __IL2CPP_IS_VALUE_TYPE = typeEnum_ != Il2CppTypeEnum::IL2CPP_TYPE_CLASS;\
-        static const int __IL2CPP_REFERENCE_TYPE_SIZE;\
-        struct ___TypeRegistration : ::custom_types::TypeRegistration { \
-            ___TypeRegistration() { \
+    namespace __custom_types_internal { \
+        struct ___TypeRegistration_##name_ : ::custom_types::TypeRegistration { \
+            ___TypeRegistration_##name_() { \
                 ::custom_types::Register::AddType(this); \
                 instance = this; \
             } \
@@ -128,7 +120,7 @@ namespace namespaze_ { \
                 return ::il2cpp_utils::GetClassFromName(baseNamespaze, baseName); \
             } \
             std::vector<Il2CppClass*> const interfaces() const override { \
-                return interfaces_; \
+                return ::custom_types::ExtractClasses<__VA_ARGS__>(); \
             } \
             constexpr Il2CppTypeEnum typeEnum() const override { \
                 return typeEnum_; \
@@ -140,9 +132,7 @@ namespace namespaze_ { \
             Il2CppClass*& klass() const override { \
                 return klass_ptr; \
             } \
-            size_t size() const override { \
-                return sizeof(___TargetType); \
-            } \
+            size_t size() const override; \
             TypeRegistration* customBase() const override { \
                 return nullptr; \
             } \
@@ -158,43 +148,29 @@ namespace namespaze_ { \
                 return instance; \
             } \
         }; \
-        uint8_t _baseFields[baseSize]; \
-        protected: \
-        name_() {}; \
-        public: \
-        name_(name_&&) = delete;\
-        name_(name_ const&) = delete;\
-        __VA_ARGS__ \
-    }; \
-    inline constexpr const int name_::__IL2CPP_REFERENCE_TYPE_SIZE = sizeof(name_);\
+    } \
 } \
 template<> \
-struct ::il2cpp_utils::il2cpp_type_check::il2cpp_no_arg_class<::namespaze_::name_*> { \
+struct ::il2cpp_utils::il2cpp_type_check::il2cpp_no_arg_class<namespaze_::name_*> { \
     static inline Il2CppClass* get() { \
-        return ::namespaze_::name_::___TypeRegistration::klass_ptr; \
+        return namespaze_::__custom_types_internal::___TypeRegistration_##name_::klass_ptr; \
     } \
 }; \
 template<> \
-struct ::il2cpp_utils::il2cpp_type_check::need_box<::namespaze_::name_> { \
+struct ::il2cpp_utils::il2cpp_type_check::need_box<namespaze_::name_> { \
     constexpr static bool value = false; \
-};
+}; \
+MARK_REF_PTR_T(namespaze_::name_); \
+class CUSTOM_TYPES_EXPORT_VISIBILITY namespaze_::name_ : \
+    public ::custom_types::TypeWrapperParent<namespaze_::name_, namespaze_::__custom_types_internal::___TypeRegistration_##name_, typeEnum_, baseSize>
 
 // Helper for declaring classes with and without interfaces with explicit inheritance
-#define ___DECLARE_TYPE_WRAPPER_INHERITANCE(namespaze_, name_, typeEnum_, baseT, dllName_, interfaces_, flags_, baseCustom, ...) \
+#define ___DECLARE_TYPE_WRAPPER_INHERITANCE(namespaze_, name_, typeEnum_, baseT, dllName_, flags_, baseCustom, ...) \
 namespace namespaze_ { \
     class name_; \
-} \
-MARK_REF_PTR_T(namespaze_::name_);\
-namespace namespaze_ { \
-    class CUSTOM_TYPES_EXPORT_VISIBILITY name_ : public baseT { \
-        using ___TargetType = name_; \
-        constexpr static auto ___Base__Size = sizeof(baseT); \
-        friend ::custom_types::Register; \
-        public: \
-        constexpr static bool __IL2CPP_IS_VALUE_TYPE = typeEnum_ != Il2CppTypeEnum::IL2CPP_TYPE_CLASS;\
-        static const int __IL2CPP_REFERENCE_TYPE_SIZE;\
-        struct ___TypeRegistration : ::custom_types::TypeRegistration { \
-            ___TypeRegistration() { \
+    namespace __custom_types_internal { \
+        struct ___TypeRegistration_##name_ : ::custom_types::TypeRegistration { \
+            ___TypeRegistration_##name_() { \
                 ::custom_types::Register::AddType(this); \
                 instance = this; \
             } \
@@ -245,12 +221,12 @@ namespace namespaze_ { \
                 return dllName_; \
             } \
             Il2CppClass* baseType() const override { \
-                auto klass = ::il2cpp_utils::il2cpp_type_check::il2cpp_no_arg_class<baseT*>::get();\
-                if (!klass->initialized) il2cpp_functions::Class_Init(klass);\
-                return klass;\
+                auto klass = ::il2cpp_utils::il2cpp_type_check::il2cpp_no_arg_class<baseT*>::get(); \
+                if (!klass->initialized) il2cpp_functions::Class_Init(klass); \
+                return klass; \
             } \
             std::vector<Il2CppClass*> const interfaces() const override { \
-                return interfaces_; \
+                return ::custom_types::ExtractClasses<__VA_ARGS__>(); \
             } \
             constexpr Il2CppTypeEnum typeEnum() const override { \
                 return typeEnum_; \
@@ -262,9 +238,7 @@ namespace namespaze_ { \
             Il2CppClass*& klass() const override { \
                 return klass_ptr; \
             } \
-            size_t size() const override { \
-                return sizeof(___TargetType); \
-            } \
+            size_t size() const override; \
             TypeRegistration* customBase() const override { \
                 return baseCustom; \
             } \
@@ -280,67 +254,63 @@ namespace namespaze_ { \
                 return instance; \
             } \
         }; \
-        protected: \
-        name_() {}; \
-        public: \
-        name_(name_&&) = delete;\
-        name_(name_ const&) = delete;\
-        __VA_ARGS__ \
-    }; \
-    inline constexpr const int name_::__IL2CPP_REFERENCE_TYPE_SIZE = sizeof(name_);\
+    } \
 } \
 template<> \
-struct ::il2cpp_utils::il2cpp_type_check::il2cpp_no_arg_class<::namespaze_::name_*> { \
+struct ::il2cpp_utils::il2cpp_type_check::il2cpp_no_arg_class<namespaze_::name_*> { \
     static inline Il2CppClass* get() { \
-        return ::namespaze_::name_::___TypeRegistration::klass_ptr; \
+        return namespaze_::__custom_types_internal::___TypeRegistration_##name_::klass_ptr; \
     } \
 }; \
 template<> \
-struct ::il2cpp_utils::il2cpp_type_check::need_box<::namespaze_::name_> { \
+struct ::il2cpp_utils::il2cpp_type_check::need_box<namespaze_::name_> { \
     constexpr static bool value = false; \
-};
+}; \
+MARK_REF_PTR_T(namespaze_::name_); \
+class CUSTOM_TYPES_EXPORT_VISIBILITY namespaze_::name_ : \
+    public ::custom_types::TypeWrapperInheritanceParent<namespaze_::name_, namespaze_::__custom_types_internal::___TypeRegistration_##name_, typeEnum_, baseT>
 
 // Declares a class with the given namespace, name, base namespace, base name, and baseSize.
 // Assumes the class being declared is non-abstract.
 // impl specifies the implementation of the class, the actual definition of the type.
 // It is recommended this holds DECLARE statements, as defined in macros.hpp
-#define DECLARE_CLASS(namespaze, name, baseNamespaze, baseName, baseSize, ...) \
-___DECLARE_TYPE_WRAPPER(namespaze, name, Il2CppTypeEnum::IL2CPP_TYPE_CLASS, baseNamespaze, baseName, baseSize, #namespaze, {}, 0, __VA_ARGS__)
+#define DECLARE_CLASS(namespaze, name, baseNamespaze, baseName, baseSize) \
+___DECLARE_TYPE_WRAPPER(namespaze, name, Il2CppTypeEnum::IL2CPP_TYPE_CLASS, baseNamespaze, baseName, baseSize, #namespaze, 0)
 
 // Declares a class with the given namespace, name, base namespace, base name, baseSize, and dll name.
 // Assumes the class being declared is non-abstract.
 // impl specifies the implementation of the class, the actual definition of the type.
 // It is recommended this holds DECLARE statements, as defined in macros.hpp
-#define DECLARE_CLASS_DLL(namespaze, name, baseNamespaze, baseName, baseSize, dllName_, ...) \
-___DECLARE_TYPE_WRAPPER(namespaze, name, Il2CppTypeEnum::IL2CPP_TYPE_CLASS, baseNamespaze, baseName, baseSize, dllName_, {}, 0, __VA_ARGS__)
+#define DECLARE_CLASS_DLL(namespaze, name, baseNamespaze, baseName, baseSize, dllName_) \
+___DECLARE_TYPE_WRAPPER(namespaze, name, Il2CppTypeEnum::IL2CPP_TYPE_CLASS, baseNamespaze, baseName, baseSize, dllName_, 0)
 
 // Declares a class with the given namespace, name, base namespace, base name, baseSize, and interface list.
 // Assumes the class being declared is non-abstract.
 // impl specifies the implementation of the class, the actual definition of the type.
 // It is recommended this holds DECLARE statements, as defined in macros.hpp
-#define DECLARE_CLASS_INTERFACES(namespaze, name, baseNamespaze, baseName, baseSize, interfaces, ...) \
-___DECLARE_TYPE_WRAPPER(namespaze, name, Il2CppTypeEnum::IL2CPP_TYPE_CLASS, baseNamespaze, baseName, baseSize, #namespaze, {interfaces}, 0, __VA_ARGS__)
+#define DECLARE_CLASS_INTERFACES(namespaze, name, baseNamespaze, baseName, baseSize, ...) \
+___DECLARE_TYPE_WRAPPER(namespaze, name, Il2CppTypeEnum::IL2CPP_TYPE_CLASS, baseNamespaze, baseName, baseSize, #namespaze, 0, __VA_ARGS__)
 
 // Declares a class with the given namespace, name, base namespace, base name, baseSize, dll name, and interface list.
 // Assumes the class being declared is non-abstract.
 // impl specifies the implementation of the class, the actual definition of the type.
 // It is recommended this holds DECLARE statements, as defined in macros.hpp
-#define DECLARE_CLASS_INTERFACES_DLL(namespaze, name, baseNamespaze, baseName, baseSize, dllName_, interfaces, ...) \
-___DECLARE_TYPE_WRAPPER(namespaze, name, Il2CppTypeEnum::IL2CPP_TYPE_CLASS, baseNamespaze, baseName, baseSize, dllName_, {interfaces}, 0, __VA_ARGS__)
+#define DECLARE_CLASS_INTERFACES_DLL(namespaze, name, baseNamespaze, baseName, baseSize, dllName_, ...) \
+___DECLARE_TYPE_WRAPPER(namespaze, name, Il2CppTypeEnum::IL2CPP_TYPE_CLASS, baseNamespaze, baseName, baseSize, dllName_, 0, __VA_ARGS__)
 
 // Declares a class with the given namespace, name, and base type.
 // Assumes the class being declared is non-abstract.
 // impl specifies the implementation of the class, the actual definition of the type.
 // It is recommended this hold other DECLARE statements, as defined in macros.hpp
-#define DECLARE_CLASS_CODEGEN(namespaze, name, baseT, ...) \
-___DECLARE_TYPE_WRAPPER_INHERITANCE(namespaze, name, Il2CppTypeEnum::IL2CPP_TYPE_CLASS, baseT, #namespaze, {}, 0, nullptr, __VA_ARGS__)
+#define DECLARE_CLASS_CODEGEN(namespaze, name, baseT) \
+___DECLARE_TYPE_WRAPPER_INHERITANCE(namespaze, name, Il2CppTypeEnum::IL2CPP_TYPE_CLASS, baseT, #namespaze, 0, nullptr)
 
 // Declares a class with the given namespace, name, base type, and dllName.
 // Assumes the class being declared is non-abstract.
 // impl specifies the implementation of the class, the actual definition of the type.
 // It is recommended this hold other DECLARE statements, as defined in macros.hpp
-#define DECLARE_CLASS_CODEGEN_DLL(namespaze, name, baseT, dllName_, ...) \
-___DECLARE_TYPE_WRAPPER_INHERITANCE(namespaze, name, Il2CppTypeEnum::IL2CPP_TYPE_CLASS, baseT, dllName_, {}, 0, nullptr, __VA_ARGS__)
+#define DECLARE_CLASS_CODEGEN_DLL(namespaze, name, baseT, dllName_) \
+___DECLARE_TYPE_WRAPPER_INHERITANCE(namespaze, name, Il2CppTypeEnum::IL2CPP_TYPE_CLASS, baseT, dllName_, 0, nullptr)
 
 // Declares a class with the given namespace, name, base type, and interface types.
 // Assumes the class being declared is non-abstract.
@@ -348,8 +318,8 @@ ___DECLARE_TYPE_WRAPPER_INHERITANCE(namespaze, name, Il2CppTypeEnum::IL2CPP_TYPE
 // It is recommended this hold other DECLARE statements, as defined in macros.hpp
 // TODO: Note that this type does NOT properly inherit its interfaces or provide conversion operators.
 // Casts WILL be necessary.
-#define DECLARE_CLASS_CODEGEN_INTERFACES(namespaze, name, baseT, interfaceTs, ...) \
-___DECLARE_TYPE_WRAPPER_INHERITANCE(namespaze, name, Il2CppTypeEnum::IL2CPP_TYPE_CLASS, baseT, #namespaze, {interfaceTs}, 0, nullptr, __VA_ARGS__)
+#define DECLARE_CLASS_CODEGEN_INTERFACES(namespaze, name, baseT, ...) \
+___DECLARE_TYPE_WRAPPER_INHERITANCE(namespaze, name, Il2CppTypeEnum::IL2CPP_TYPE_CLASS, baseT, #namespaze, 0, nullptr, __VA_ARGS__)
 
 // Declares a class with the given namespace, name, base type, dll name, and interface types.
 // Assumes the class being declared is non-abstract.
@@ -357,50 +327,50 @@ ___DECLARE_TYPE_WRAPPER_INHERITANCE(namespaze, name, Il2CppTypeEnum::IL2CPP_TYPE
 // It is recommended this hold other DECLARE statements, as defined in macros.hpp
 // TODO: Note that this type does NOT properly inherit its interfaces or provide conversion operators.
 // Casts WILL be necessary.
-#define DECLARE_CLASS_CODEGEN_INTERFACES_DLL(namespaze, name, baseT, interfaceTs, dllName_, ...) \
-___DECLARE_TYPE_WRAPPER_INHERITANCE(namespaze, name, Il2CppTypeEnum::IL2CPP_TYPE_CLASS, baseT, dllName_, interfaceTs, 0, nullptr, __VA_ARGS__)
+#define DECLARE_CLASS_CODEGEN_INTERFACES_DLL(namespaze, name, baseT, dllName_, ...) \
+___DECLARE_TYPE_WRAPPER_INHERITANCE(namespaze, name, Il2CppTypeEnum::IL2CPP_TYPE_CLASS, baseT, dllName_, 0, nullptr, __VA_ARGS__)
 
 // Declares a class with the given namespace, name, and base type (WHICH MUST BE A DECLARE TYPE OF ITS OWN!)
 // Assumes the class being declared is non-abstract.
 // impl specifies the implementation of the class, the actual definition of the type.
 // It is recommended this hold other DECLARE statements, as defined in macros.hpp
-#define DECLARE_CLASS_CUSTOM(namespaze, name, baseCustomT, ...) \
-___DECLARE_TYPE_WRAPPER_INHERITANCE(namespaze, name, Il2CppTypeEnum::IL2CPP_TYPE_CLASS, baseCustomT, #namespaze, {}, 0, baseCustomT::___TypeRegistration::get(), __VA_ARGS__)
+#define DECLARE_CLASS_CUSTOM(namespaze, name, baseCustom) \
+___DECLARE_TYPE_WRAPPER_INHERITANCE(namespaze, name, Il2CppTypeEnum::IL2CPP_TYPE_CLASS, baseCustom, #namespaze, 0, baseCustom::___TypeRegistration::get())
 
 // Declares a class with the given namespace, name, base type (WHICH MUST BE A DECLARE TYPE OF ITS OWN!), and dll name.
 // Assumes the class being declared is non-abstract.
 // impl specifies the implementation of the class, the actual definition of the type.
 // It is recommended this hold other DECLARE statements, as defined in macros.hpp
-#define DECLARE_CLASS_CUSTOM_DLL(namespaze, name, baseCustomT, dllName_, ...) \
-___DECLARE_TYPE_WRAPPER_INHERITANCE(namespaze, name, Il2CppTypeEnum::IL2CPP_TYPE_CLASS, baseCustomT, dllName_, {}, 0, baseCustomT::___TypeRegistration::get(), __VA_ARGS__)
+#define DECLARE_CLASS_CUSTOM_DLL(namespaze, name, baseCustom, dllName_) \
+___DECLARE_TYPE_WRAPPER_INHERITANCE(namespaze, name, Il2CppTypeEnum::IL2CPP_TYPE_CLASS, baseCustom, dllName_, 0, baseCustom::___TypeRegistration::get())
 
 // Declares a class with the given namespace, name, and base type (WHICH MUST BE A DECLARE TYPE OF ITS OWN!), and interface list.
 // Assumes the class being declared is non-abstract.
 // impl specifies the implementation of the class, the actual definition of the type.
 // It is recommended this hold other DECLARE statements, as defined in macros.hpp
-#define DECLARE_CLASS_CUSTOM_INTERFACES(namespaze, name, baseCustomT, interfaceTs, ...) \
-___DECLARE_TYPE_WRAPPER_INHERITANCE(namespaze, name, Il2CppTypeEnum::IL2CPP_TYPE_CLASS, baseCustomT, #namespaze, interfaceTs, 0, baseCustomT::___TypeRegistration::get(), __VA_ARGS__)
+#define DECLARE_CLASS_CUSTOM_INTERFACES(namespaze, name, baseCustom, ...) \
+___DECLARE_TYPE_WRAPPER_INHERITANCE(namespaze, name, Il2CppTypeEnum::IL2CPP_TYPE_CLASS, baseCustom, #namespaze, 0, baseCustom::___TypeRegistration::get(), __VA_ARGS__)
 
 // Declares a class with the given namespace, name, and base type (WHICH MUST BE A DECLARE TYPE OF ITS OWN!), dll name, and interface list.
 // Assumes the class being declared is non-abstract.
 // impl specifies the implementation of the class, the actual definition of the type.
 // It is recommended this hold other DECLARE statements, as defined in macros.hpp
-#define DECLARE_CLASS_CUSTOM_INTERFACES_DLL(namespaze, name, baseCustomT, dllName_, interfaceTs, ...) \
-___DECLARE_TYPE_WRAPPER_INHERITANCE(namespaze, name, Il2CppTypeEnum::IL2CPP_TYPE_CLASS, baseCustomT, dllName_, interfaceTs, 0, baseCustomT::___TypeRegistration::get(), __VA_ARGS__)
+#define DECLARE_CLASS_CUSTOM_INTERFACES_DLL(namespaze, name, baseCustom, dllName_, ...) \
+___DECLARE_TYPE_WRAPPER_INHERITANCE(namespaze, name, Il2CppTypeEnum::IL2CPP_TYPE_CLASS, baseCustom, dllName_, 0, baseCustom::___TypeRegistration::get(), __VA_ARGS__)
 
 // Declares a value type with the given namespace, name, base namespace, base name, and baseSize.
 // Assumes the struct being declared is non-generic/abstract.
 // impl specifies the implementation of the class, which is the actual definition of the type.
 // It is recommended that this holds DECLARE statements as defined in macros.hpp, but fields can ultimately be of any type.
-#define DECLARE_VALUE(namespaze, name, baseNamespaze, baseName, baseSize, ...) \
-___DECLARE_TYPE_WRAPPER(namespaze, name, Il2CppTypeEnum::IL2CPP_TYPE_VALUETYPE, baseNamespaze, baseName, baseSize, #namespaze, {}, 0, __VA_ARGS__)
+#define DECLARE_VALUE(namespaze, name, baseNamespaze, baseName, baseSize) \
+___DECLARE_TYPE_WRAPPER(namespaze, name, Il2CppTypeEnum::IL2CPP_TYPE_VALUETYPE, baseNamespaze, baseName, baseSize, #namespaze, 0)
 
 // Declares a value type with the given namespace, name, and base type.
 // Assumes the struct being declared is non-abstract.
 // impl specifies the implementation of the struct, the actual definition of the type.
 // It is recommended that this holds DECLARE statements as defined in macros.hpp, but fields can ultimately be of any type.
-#define DECLARE_VALUE_CODEGEN(namespaze, name, baseT, ...) \
-___DECLARE_TYPE_WRAPPER_INHERITANCE(namespaze, name, Il2CppTypeEnum::IL2CPP_TYPE_VALUETYPE, baseT, #namespaze, {}, 0, nullptr, __VA_ARGS__)
+#define DECLARE_VALUE_CODEGEN(namespaze, name, baseT) \
+___DECLARE_TYPE_WRAPPER_INHERITANCE(namespaze, name, Il2CppTypeEnum::IL2CPP_TYPE_VALUETYPE, baseT, #namespaze, 0, nullptr)
 
 #ifdef DEFINE_TYPE
 #error "DEFINE_TYPE is already defined! Undefine it before including macros.hpp!"
@@ -411,7 +381,8 @@ ___DECLARE_TYPE_WRAPPER_INHERITANCE(namespaze, name, Il2CppTypeEnum::IL2CPP_TYPE
 static namespaze::name::___TypeRegistration __registration_instance_##name; \
 char* namespaze::name::___TypeRegistration::st_fields; \
 Il2CppClass* namespaze::name::___TypeRegistration::klass_ptr; \
-bool namespaze::name::___TypeRegistration::init = false;
+bool namespaze::name::___TypeRegistration::init = false; \
+size_t namespaze::name::___TypeRegistration::size() const { return sizeof(namespaze::name); };
 
 // TODO: Add a way of declaring abstract/interface types.
 // This requires messing with method slots even more than I do right now.

--- a/shared/util.hpp
+++ b/shared/util.hpp
@@ -3,6 +3,7 @@
 #include "beatsaber-hook/shared/utils/type-concepts.hpp"
 #include "beatsaber-hook/shared/utils/il2cpp-functions.hpp"
 #include "beatsaber-hook/shared/utils/il2cpp-utils-exceptions.hpp"
+#include "beatsaber-hook/shared/utils/il2cpp-utils.hpp"
 
 namespace custom_types {
     template<class F>
@@ -29,9 +30,38 @@ namespace custom_types {
         }
     };
 
+    template<size_t N>
+    struct string_literal {
+        constexpr string_literal(const char (&str)[N]) {
+            std::copy_n(str, N, value);
+        }
+        char value[N];
+    };
+
+    template<string_literal namespaze_, string_literal name_>
+    struct interface_helper {
+        static auto constexpr namespaze = namespaze_;
+        static auto constexpr name = name_;
+    };
+
     struct CUSTOM_TYPES_EXPORT NullAccessException : il2cpp_utils::exceptions::StackTraceException {
         NullAccessException() : il2cpp_utils::exceptions::StackTraceException("Null instance access on a custom type field!") {}
     };
+
+    template<typename T>
+    Il2CppClass* ExtractClass() {
+        return ::il2cpp_utils::il2cpp_type_check::il2cpp_no_arg_class<T>::get();
+    }
+    template<typename T>
+    requires requires () { ::il2cpp_utils::GetClassFromName(T::namespaze.value, T::name.value); }
+    Il2CppClass* ExtractClass() {
+        return ::il2cpp_utils::GetClassFromName(T::namespaze.value, T::name.value);
+    }
+
+    template<typename... Ts>
+    std::vector<Il2CppClass*> ExtractClasses() {
+        return {ExtractClass<Ts>()...};
+    }
 
 #if __has_feature(cxx_exceptions)
     #define CT_FIELD_ACCESS_CHECK(inst) if (!static_cast<const void*>(inst)) throw ::custom_types::NullAccessException()

--- a/src/test-coroutine.cpp
+++ b/src/test-coroutine.cpp
@@ -8,81 +8,78 @@ using namespace custom_types::Helpers;
 
 modloader::ModInfo modInfo{ MOD_ID"-test", VERSION, VERSION_LONG };
 
-Logger& modLogger() {
-    static auto myLogger = new Logger(modInfo, LoggerOptions(false, true));
-    return *myLogger;
-}
+static constexpr auto logger = ::custom_types::logger;
 
 Coroutine testNestedCoro(int n) {
-    modLogger().debug("begin nested coro");
+    logger.debug("begin nested coro");
     co_yield nullptr;
-    // modLogger().debug("one step nested coro");
+    // logger.debug("one step nested coro");
     // This will not be deleted by GC, as it will be stored as a field in the coro when invoked.
     co_yield reinterpret_cast<enumeratorT>(CRASH_UNLESS(il2cpp_utils::New("UnityEngine", "WaitForSecondsRealtime", 2.3f)));
-    modLogger().debug("yielding until: {}", n);
+    logger.debug("yielding until: {}", n);
     for (int i = 0; i < n; i++) {
-        modLogger().debug("nested coro yield: {}", i);
+        logger.debug("nested coro yield: {}", i);
         co_yield nullptr;
     }
     co_return;
-    modLogger().debug("nested coroutine complete");
+    logger.debug("nested coroutine complete");
 }
 
 Coroutine testRecursiveCall() {
-    modLogger().debug("Recursive call start!");
+    logger.debug("Recursive call start!");
     auto instance = CoroutineHelper::New<il2cpp_utils::CreationType::Manual>(testNestedCoro, 3);
-    modLogger().debug("Recursive call yield 1 {}!", fmt::ptr(instance.convert()));
+    logger.debug("Recursive call yield 1 {}!", fmt::ptr(instance.convert()));
     co_yield instance;
     // Reset instance and try again
-    modLogger().debug("Recursive yield reset!");
+    logger.debug("Recursive yield reset!");
     instance->Reset();
 
-    modLogger().debug("Recursive call yield 2! {}", fmt::ptr(instance.convert()));
+    logger.debug("Recursive call yield 2! {}", fmt::ptr(instance.convert()));
     co_yield instance;
 
-    modLogger().debug("all done");
+    logger.debug("all done");
     co_return;
 }
 
 Coroutine testWaitForSeconds() {
-    modLogger().debug("About to wait!");
+    logger.debug("About to wait!");
     auto start = std::chrono::system_clock::now();
     co_yield reinterpret_cast<enumeratorT>(CRASH_UNLESS(il2cpp_utils::New("UnityEngine", "WaitForSecondsRealtime", 2.3f)));
     auto end = std::chrono::system_clock::now();
 
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
 
-    modLogger().debug("I have performed a wait! {}ms", duration);
+    logger.debug("I have performed a wait! {}ms", duration);
     co_return;
 }
 
 CUSTOM_TYPES_FUNC void setup(CModInfo* info) {
     *info = modInfo.to_c();
-    modLogger().debug("Completed setup!");
+    logger.debug("Completed setup!");
 }
 
 MAKE_HOOK_FIND_CLASS_UNSAFE_INSTANCE(MainMenuViewController_DidActivate, "", "MainMenuViewController", "DidActivate", void, Il2CppObject* self, bool firstActivation, bool addedToHierarchy,
                                      bool screenSystemEnabling) {
     MainMenuViewController_DidActivate(self, firstActivation, addedToHierarchy, screenSystemEnabling);
 
-    modLogger().debug("Starting coroutine");
+    logger.debug("Starting coroutine");
 
     il2cpp_utils::RunMethod(self, "StartCoroutine", custom_types::Helpers::CoroutineHelper::New(testWaitForSeconds()));
     il2cpp_utils::RunMethod(self, "StartCoroutine", custom_types::Helpers::CoroutineHelper::New(testRecursiveCall()));
 }
 
 MAKE_HOOK(abort_hook, nullptr, void) {
-    modLogger().info("abort was called!");
-    modLogger().Backtrace(40);
+    logger.info("abort was called!");
+    logger.Backtrace(40);
     abort_hook();
 }
 
 CUSTOM_TYPES_FUNC void load() {
-    INSTALL_HOOK(modLogger(), MainMenuViewController_DidActivate);
+    INSTALL_HOOK(logger, MainMenuViewController_DidActivate);
 
     auto libc = dlopen("libc.so", RTLD_NOW);
     auto abort_addr = dlsym(libc, "abort");
-    INSTALL_HOOK_DIRECT(modLogger(), abort_hook, abort_addr);
+    INSTALL_HOOK_DIRECT(logger, abort_hook, abort_addr);
 }
 
 #endif

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -19,51 +19,49 @@
 
 modloader::ModInfo modInfo{ "test", "0.0.0", 0 };
 
-Logger& modLogger() {
-    static auto myLogger = new Logger(modInfo);
-    return *myLogger;
-}
+static constexpr auto logger = ::custom_types::logger;
 
-DECLARE_CLASS(Il2CppNamespace, MyType, "UnityEngine", "MonoBehaviour", sizeof(Il2CppObject) + sizeof(void*),
-              // TODO: Fields need to be copied from base type, size needs to be adjusted to match, offsets of all declared fields need to be correct
-              // DECLARE_INSTANCE_FIELD(int, x);
-              // DECLARE_INSTANCE_FIELD(Vector3, y);
+DECLARE_CLASS(Il2CppNamespace, MyType, "UnityEngine", "MonoBehaviour", sizeof(Il2CppObject) + sizeof(void*)) {
+    // TODO: Fields need to be copied from base type, size needs to be adjusted to match, offsets of all declared fields need to be correct
+    // DECLARE_INSTANCE_FIELD(int, x);
+    // DECLARE_INSTANCE_FIELD(Vector3, y);
 
-              DECLARE_CTOR(ctor);
+    DECLARE_CTOR(ctor);
 
-              DECLARE_INSTANCE_METHOD(void, Start);
+    DECLARE_INSTANCE_METHOD(void, Start);
 
-              DECLARE_STATIC_METHOD(void, Test, int x, float y);
+    DECLARE_STATIC_METHOD(void, Test, int x, float y);
 
-              DECLARE_INSTANCE_METHOD(int, asdf, int q);
+    DECLARE_INSTANCE_METHOD(int, asdf, int q);
 
-              DECLARE_STATIC_FIELD(int, x);
+    DECLARE_STATIC_FIELD(int, x);
 
-              DECLARE_OVERRIDE_METHOD(Il2CppString*, ToString, il2cpp_utils::FindMethod("UnityEngine", "Object", "ToString"));)
+    DECLARE_OVERRIDE_METHOD(Il2CppString*, ToString, il2cpp_utils::FindMethod("UnityEngine", "Object", "ToString"));
+};
 
 DEFINE_TYPE(Il2CppNamespace, MyType);
 
 void Il2CppNamespace::MyType::ctor() {
-    modLogger().debug("Called Il2CppNamespace::MyType::ctor");
+    logger.debug("Called Il2CppNamespace::MyType::ctor");
     // y = {1, 2, 3};
     // x = 5;
 }
 
 void Il2CppNamespace::MyType::Start() {
-    modLogger().debug("Called Il2CppNamespace::MyType::Start!");
-    modLogger().debug("Return of asdf(1): {}", asdf(1));
+    logger.debug("Called Il2CppNamespace::MyType::Start!");
+    logger.debug("Return of asdf(1): {}", asdf(1));
     // Runtime invoke it.
     // We ARE NOT able to call GetClassFromName.
     // This is because our class name is NOT in the nameToClassHashTable
     // However, we ARE able to get our Il2CppClass* via the klass private static field of this type.
     auto* il2cppKlass = il2cpp_utils::GetClassFromName("Il2CppNamespace", "MyType");
-    modLogger().debug("il2cpp obtained klass: {}", fmt::ptr(il2cppKlass));
-    modLogger().debug("klass: {}", fmt::ptr(___TypeRegistration::klass_ptr));
+    logger.debug("il2cpp obtained klass: {}", fmt::ptr(il2cppKlass));
+    logger.debug("klass: {}", fmt::ptr(___TypeRegistration::klass_ptr));
     auto* asdfMethod = il2cpp_utils::FindMethodUnsafe(___TypeRegistration::klass_ptr, "asdf", 1);
-    modLogger().debug("asdf method info: {}", fmt::ptr(asdfMethod));
-    // modLogger().debug("x: {}", x);
-    // modLogger().debug("y: ({}, {}, {})", y.x, y.y, y.z);
-    modLogger().debug("runtime invoke of asdf(1): {}", CRASH_UNLESS(il2cpp_utils::RunMethod<int>(this, asdfMethod, 1)));
+    logger.debug("asdf method info: {}", fmt::ptr(asdfMethod));
+    // logger.debug("x: {}", x);
+    // logger.debug("y: ({}, {}, {})", y.x, y.y, y.z);
+    logger.debug("runtime invoke of asdf(1): {}", CRASH_UNLESS(il2cpp_utils::RunMethodOpt<int>(this, asdfMethod, 1)));
 }
 
 int Il2CppNamespace::MyType::asdf(int q) {
@@ -72,28 +70,31 @@ int Il2CppNamespace::MyType::asdf(int q) {
 
 Il2CppString* Il2CppNamespace::MyType::ToString() {
     // We want to create a C# string that is different than from what might otherwise be expected!
-    modLogger().info("Calling custom ToString!");
+    logger.info("Calling custom ToString!");
     return il2cpp_utils::newcsstr("My Custom ToString!");
 }
 
 void Il2CppNamespace::MyType::Test([[maybe_unused]] int x, [[maybe_unused]] float y) {
-    modLogger().debug("Called Il2CppNamespace::MyType::Test!");
+    logger.debug("Called Il2CppNamespace::MyType::Test!");
 }
 
-DECLARE_CLASS_DLL(Il2CppNamespace, MyTypeDllTest, "UnityEngine", "MonoBehaviour", sizeof(Il2CppObject) + sizeof(void*), "MyCoolDll.dll", DECLARE_CTOR(ctor);)
+DECLARE_CLASS_DLL(Il2CppNamespace, MyTypeDllTest, "UnityEngine", "MonoBehaviour", sizeof(Il2CppObject) + sizeof(void*), "MyCoolDll.dll") {
+    DECLARE_CTOR(ctor);
+};
 
 DEFINE_TYPE(Il2CppNamespace, MyTypeDllTest);
 
 void Il2CppNamespace::MyTypeDllTest::ctor() {
-    modLogger().debug("MyTypeDllTest debug call!");
+    logger.debug("MyTypeDllTest debug call!");
     custom_types::logImage(classof(MyTypeDllTest*)->image);
 }
 
-DECLARE_CLASS_INTERFACES(Il2CppNamespace, MyCustomBeatmapLevelPackCollection, "System", "Object", sizeof(Il2CppObject), (il2cpp_utils::GetClassFromName("", "IBeatmapLevelPackCollection")),
-                         DECLARE_INSTANCE_FIELD(Il2CppArray*, wrappedArr);
+DECLARE_CLASS_INTERFACES(Il2CppNamespace, MyCustomBeatmapLevelPackCollection, "System", "Object", sizeof(Il2CppObject), INTERFACE_NAME("", "IBeatmapLevelPackCollection")) {
+    DECLARE_INSTANCE_FIELD(Il2CppArray*, wrappedArr);
 
-                         DECLARE_OVERRIDE_METHOD(Il2CppArray*, get_beatmapLevelPacks, il2cpp_utils::FindMethod("", "IBeatmapLevelPackCollection", "get_beatmapLevelPacks"));
-                         DECLARE_CTOR(ctor, Il2CppArray* originalArray);)
+    DECLARE_OVERRIDE_METHOD(Il2CppArray*, get_beatmapLevelPacks, il2cpp_utils::FindMethod("", "IBeatmapLevelPackCollection", "get_beatmapLevelPacks"));
+    DECLARE_CTOR(ctor, Il2CppArray* originalArray);
+};
 
 DEFINE_TYPE(Il2CppNamespace, MyCustomBeatmapLevelPackCollection);
 
@@ -101,29 +102,31 @@ void Il2CppNamespace::MyCustomBeatmapLevelPackCollection::ctor(Il2CppArray* orig
     // We want to basically wrap the original instance.
     // Also log.
     wrappedArr = originalArray;
-    modLogger().debug("Added original array: {}", fmt::ptr(originalArray));
+    logger.debug("Added original array: {}", fmt::ptr(originalArray));
 }
 
 Il2CppArray* Il2CppNamespace::MyCustomBeatmapLevelPackCollection::get_beatmapLevelPacks() {
-    modLogger().debug("My cool getter wrappedArr: {}!", fmt::ptr(wrappedArr));
+    logger.debug("My cool getter wrappedArr: {}!", fmt::ptr(wrappedArr));
     return wrappedArr;
 }
 
-DECLARE_CLASS_CUSTOM(Il2CppNamespace, MyCustomBeatmapCollection2, Il2CppNamespace::MyCustomBeatmapLevelPackCollection, DECLARE_CTOR(ctor, Il2CppArray* originalArray);)
+DECLARE_CLASS_CUSTOM(Il2CppNamespace, MyCustomBeatmapCollection2, Il2CppNamespace::MyCustomBeatmapLevelPackCollection) {
+    DECLARE_CTOR(ctor, Il2CppArray* originalArray);
+};
 
 DEFINE_TYPE(Il2CppNamespace, MyCustomBeatmapCollection2);
 
 void Il2CppNamespace::MyCustomBeatmapCollection2::ctor(Il2CppArray* originalArray) {
     wrappedArr = originalArray;
-    modLogger().debug("Custom inherited type original array: {}", fmt::ptr(originalArray));
+    logger.debug("Custom inherited type original array: {}", fmt::ptr(originalArray));
 }
 
 // TODO: Self references still do not work!
-// DECLARE_CLASS(SmallTest, Test, "System", "Object", sizeof(Il2CppObject),
+// DECLARE_CLASS(SmallTest, Test, "System", "Object", sizeof(Il2CppObject)) {
 //     DECLARE_STATIC_METHOD(SmallTest::Test*, SelfRef, int x);
 //     DECLARE_STATIC_FIELD(SmallTest::Test*, selfRefField);
 //     DECLARE_STATIC_FIELD(Il2CppNamespace::MyType*, AnotherRef);
-// )
+// };
 
 // DEFINE_TYPE(SmallTest, Test);
 
@@ -131,34 +134,46 @@ void Il2CppNamespace::MyCustomBeatmapCollection2::ctor(Il2CppArray* originalArra
 //     return CRASH_UNLESS(il2cpp_utils::New<SmallTest::Test*>());
 // }
 
-DECLARE_VALUE(ValueTest, Test, "System", "ValueType", 0, DECLARE_INSTANCE_FIELD(int, x); DECLARE_INSTANCE_FIELD(int, y); DECLARE_INSTANCE_FIELD(int, z);)
+DECLARE_VALUE(ValueTest, Test, "System", "ValueType", 0) {
+    DECLARE_INSTANCE_FIELD(int, x);
+    DECLARE_INSTANCE_FIELD(int, y);
+    DECLARE_INSTANCE_FIELD(int, z);
+};
 
 DEFINE_TYPE(ValueTest, Test);
 
-DECLARE_CLASS(SmallTest, TestIt2, "System", "Object", sizeof(Il2CppObject), std::vector<void*> allocField; int x = 3; DECLARE_CTOR(ctor); DECLARE_SIMPLE_DTOR();)
+DECLARE_CLASS(SmallTest, TestIt2, "System", "Object", sizeof(Il2CppObject)) {
+    std::vector<void*> allocField;
+    int x = 3;
+    DECLARE_CTOR(ctor);
+    DECLARE_SIMPLE_DTOR();
+};
 
 DEFINE_TYPE(SmallTest, TestIt2);
 
 void SmallTest::TestIt2::ctor() {
     // This invokes the C++ constructor for this type
     INVOKE_CTOR();
-    modLogger().debug("X is: {}", x);
+    logger.debug("X is: {}", x);
 }
 
-DECLARE_CLASS(SmallTest, TestIt3, "System", "Object", sizeof(Il2CppObject),
-              // These fields are initialized in the DEFAULT_CTOR
-              std::vector<void*> allocField;
-              int x = 3; DECLARE_DEFAULT_CTOR(); DECLARE_SIMPLE_DTOR();)
+DECLARE_CLASS(SmallTest, TestIt3, "System", "Object", sizeof(Il2CppObject)) {
+    // These fields are initialized in the DEFAULT_CTOR
+    public:
+    std::vector<void*> allocField;
+    int x = 3;
+    DECLARE_DEFAULT_CTOR();
+    DECLARE_SIMPLE_DTOR();
+};
 
 DEFINE_TYPE(SmallTest, TestIt3);
 
-// DECLARE_CLASS_INTERFACES(Il2CppNamespace, MyBeatmapObjectManager, "", "BeatmapObjectManager",
-//     il2cpp_utils::GetClassFromName("", "IBeatmapObjectSpawner"),
+// DECLARE_CLASS_INTERFACES(Il2CppNamespace, MyBeatmapObjectManager, "", "BeatmapObjectManager", INTERFACE_NAME("", "IBeatmapObjectSpawner")) {
 //     DECLARE_CTOR(ctor);
-//     DECLARE_INTERFACE_METHOD(void, SpawnBasicNote, il2cpp_utils::FindMethodUnsafe("", "IBeatmapObjectSpawner", "SpawnBasicNote", 11),
+//     DECLARE_OVERRIDE_METHOD(void, SpawnBasicNote, il2cpp_utils::FindMethodUnsafe("", "IBeatmapObjectSpawner", "SpawnBasicNote", 11),
 //     NoteData* noteData, Vector3 moveStartPos, Vector3 moveEndPos, Vector3 jumpEndPos, float moveDuration, float jumpDuration, float jumpGravity, float rotation, bool disappearingArrow, bool
 //     ghostNote, float cutDirectionAngleOffset); REGISTER_FUNCTION(MyBeatmapObjectManager,
-//         modLogger().debug("Registering MyBeatmapObjectManager!");
+//         logger.debug("Registering MyBeatmapObjectManager!");
 //         REGISTER_METHOD(ctor);
 //         REGISTER_METHOD(SpawnBasicNote);
 //     )
@@ -167,15 +182,15 @@ DEFINE_TYPE(SmallTest, TestIt3);
 //     static inline void setActual(Il2CppObject* beatmapObjectManager) {
 //         actualBeatmapObjectManager = actualBeatmapObjectManager;
 //     }
-// )
+// };
 
 // void Il2CppNamespace::MyBeatmapObjectManager::ctor() {
-//     modLogger().debug("Called Il2CppNamespace::MyBeatmapObjectManager::ctor");
+//     logger.debug("Called Il2CppNamespace::MyBeatmapObjectManager::ctor");
 // }
 
 // void Il2CppNamespace::MyBeatmapObjectManager::SpawnBasicNote(NoteData* noteData, Vector3 moveStartPos, Vector3 moveEndPos, Vector3 jumpEndPos, float moveDuration, float jumpDuration, float
 // jumpGravity, float rotation, bool disappearingArrow, bool ghostNote, float cutDirectionAngleOffset) {
-//     modLogger().debug("Called Il2CppNamespace::MyBeatmapObjectManager::SpawnBasicNote, calling orig now!");
+//     logger.debug("Called Il2CppNamespace::MyBeatmapObjectManager::SpawnBasicNote, calling orig now!");
 //     auto* method = il2cpp_utils::FindMethodUnsafe("", "BeatmapObjectManager", "SpawnBasicNote", 11);
 //     il2cpp_utils::RunMethod(actualBeatmapObjectManager, method, noteData, moveStartPos, moveEndPos, jumpEndPos, moveDuration, jumpDuration, jumpGravity, rotation);
 // }
@@ -186,30 +201,30 @@ CUSTOM_TYPES_FUNC void setup(CModInfo* info) {
     info->id = MOD_ID;
     info->version = VERSION;
     info->version_long = VERSION_LONG;
-    modInfo.assign(info);
-    modLogger().debug("Completed setup!");
+    modInfo.assign(*info);
+    logger.debug("Completed setup!");
 }
 
 MAKE_HOOK_FIND_CLASS_UNSAFE_INSTANCE(MainMenuViewController_DidActivate, "", "MainMenuViewController", "DidActivate", void, Il2CppObject* self, bool firstActivation, bool addedToHierarchy,
                                      bool screenSystemEnabling) {
-    modLogger().debug("MainMenuViewController.DidActivate!");
+    logger.debug("MainMenuViewController.DidActivate!");
     MainMenuViewController_DidActivate(self, firstActivation, addedToHierarchy, screenSystemEnabling);
-    modLogger().debug("Getting GO...");
-    auto* go = RET_V_UNLESS(modLogger(), il2cpp_utils::GetPropertyValue(self, "gameObject").value_or(nullptr));
-    modLogger().debug("Got GO: {}", fmt::ptr(go));
+    logger.debug("Getting GO...");
+    auto* go = RET_V_UNLESS(logger, il2cpp_utils::GetPropertyValue(self, "gameObject").value_or(nullptr));
+    logger.debug("Got GO: {}", fmt::ptr(go));
     custom_types::logAll(classof(Il2CppNamespace::MyType*));
     custom_types::logAll(classof(Il2CppNamespace::MyType*)->parent);
     auto* customType = il2cpp_utils::GetSystemType(custom_types::Register::classes[0]);
-    modLogger().debug("Custom System.Type: {}", fmt::ptr(customType));
-    auto* strType = RET_V_UNLESS(modLogger(), il2cpp_utils::RunMethod<Il2CppString*>(customType, "ToString"));
-    modLogger().debug("ToString: {}", to_utf8(csstrtostr(strType)).data());
-    auto* name = RET_V_UNLESS(modLogger(), il2cpp_utils::GetPropertyValue<Il2CppString*>(customType, "Name"));
-    modLogger().debug("Name: {}", to_utf8(csstrtostr(name)).c_str());
-    modLogger().debug("Actual type: {}", fmt::ptr(&custom_types::Register::classes[0]->byval_arg));
-    modLogger().debug("Type: {}", fmt::ptr(customType->type));
+    logger.debug("Custom System.Type: {}", fmt::ptr(customType));
+    auto strType = RET_V_UNLESS(logger, il2cpp_utils::RunMethodOpt<StringW>(customType, "ToString"));
+    logger.debug("ToString: {}", strType);
+    auto name = RET_V_UNLESS(logger, il2cpp_utils::GetPropertyValue<StringW>(customType, "Name"));
+    logger.debug("Name: {}", name);
+    logger.debug("Actual type: {}", fmt::ptr(&custom_types::Register::classes[0]->byval_arg));
+    logger.debug("Type: {}", fmt::ptr(customType->type));
     // crashNow = true;
-    auto* comp = RET_V_UNLESS(modLogger(), il2cpp_utils::RunMethod(go, "AddComponent", customType));
-    modLogger().debug("Custom Type added as a component: {}", fmt::ptr(comp));
+    auto* comp = RET_V_UNLESS(logger, il2cpp_utils::RunMethodOpt<Il2CppObject*>(go, "AddComponent", customType));
+    logger.debug("Custom Type added as a component: {}", fmt::ptr(comp));
 }
 
 // static bool first = false;
@@ -217,21 +232,21 @@ MAKE_HOOK_FIND_CLASS_UNSAFE_INSTANCE(MainMenuViewController_DidActivate, "", "Ma
 //     if (!first) {
 //         first = true;
 //         // We log, set the interface field, log, and then call orig.
-//         modLogger().debug("Calling BeatmapObjectSpawnController.SpawnNote!");
+//         logger.debug("Calling BeatmapObjectSpawnController.SpawnNote!");
 //         auto* created = CRASH_UNLESS(il2cpp_utils::New<Il2CppNamespace::MyBeatmapObjectManager*>("Il2CppNamespace", "MyBeatmapObjectManager"));
-//         modLogger().debug("Created MyBeatmapObjectManager: {}!", fmt::ptr(created));
+//         logger.debug("Created MyBeatmapObjectManager: {}!", fmt::ptr(created));
 //         auto* old = CRASH_UNLESS(il2cpp_utils::GetFieldValue(self, "_beatmapObjectSpawner"));
-//         modLogger().debug("Got old: {}!", fmt::ptr(old));
+//         logger.debug("Got old: {}!", fmt::ptr(old));
 //         Il2CppNamespace::MyBeatmapObjectManager::setActual(old);
-//         modLogger().debug("Set actual to old!");
+//         logger.debug("Set actual to old!");
 //         il2cpp_utils::SetFieldValue(self, "_beatmapObjectSpawner", created);
-//         modLogger().debug("Set current to MyBeatmapObjectManager: {}!", fmt::ptr(created));
+//         logger.debug("Set current to MyBeatmapObjectManager: {}!", fmt::ptr(created));
 //         // Call orig
 //         BeatmapObjectSpawnController_SpawnNote(self, noteData, cutDirAngle);
-//         modLogger().debug("Called orig!");
+//         logger.debug("Called orig!");
 //         il2cpp_utils::SetFieldValue(self, "_beatmapObjectSpawner", old);
 //         // Then, we set the field back.
-//         modLogger().debug("Set field back to old: {}", fmt::ptr(old));
+//         logger.debug("Set field back to old: {}", fmt::ptr(old));
 //     } else {
 //         BeatmapObjectSpawnController_SpawnNote(self, noteData, cutDirAngle);
 //     }
@@ -240,13 +255,13 @@ MAKE_HOOK_FIND_CLASS_UNSAFE_INSTANCE(MainMenuViewController_DidActivate, "", "Ma
 MAKE_HOOK_FIND_CLASS_UNSAFE_INSTANCE(BeatmapLevelModels_UpdateAllLoadedBeatmapLevelPacks, "", "BeatmapLevelModels", "UpdateAllLoadedBeatmapLevelPacks", void, Il2CppObject* self) {
     BeatmapLevelModels_UpdateAllLoadedBeatmapLevelPacks(self);
     auto* existing = CRASH_UNLESS(il2cpp_utils::GetFieldValue(self, "_allLoadedBeatmapLevelPackCollection"));
-    modLogger().debug("Existing: {}", fmt::ptr(existing));
+    logger.debug("Existing: {}", fmt::ptr(existing));
     auto* arr = CRASH_UNLESS(il2cpp_utils::GetPropertyValue(existing, "beatmapLevelPacks"));
-    modLogger().debug("Existing arr: {}", fmt::ptr(arr));
-    modLogger().debug("Constructing custom type and setting it to field!");
+    logger.debug("Existing arr: {}", fmt::ptr(arr));
+    logger.debug("Constructing custom type and setting it to field!");
     // auto* myType = CRASH_UNLESS(il2cpp_utils::New<Il2CppNamespace::MyCustomBeatmapLevelPackCollection*>(arr));
     auto myType = Il2CppNamespace::MyCustomBeatmapLevelPackCollection::New_ctor((Il2CppArray*)arr);
-    modLogger().debug("Created new type: {}", fmt::ptr(myType));
+    logger.debug("Created new type: {}", fmt::ptr(myType));
     auto* k = il2cpp_functions::object_get_class(existing);
     custom_types::logAll(k);
     k = il2cpp_functions::object_get_class((Il2CppObject*)myType);
@@ -270,6 +285,8 @@ CUSTOM_TYPES_FUNC void load() {
     il2cpp_utils::LogClass(logger, custom_types::Register::classes[0]);
     il2cpp_utils::LogClass(logger, custom_types::Register::classes[1]);
     il2cpp_utils::New<SmallTest::TestIt2*>();
+    auto* testIt3 = CRASH_UNLESS(il2cpp_utils::New<SmallTest::TestIt3*>());
+    logger.debug("testIt3 default value {}", testIt3->x);
     for (auto itr : custom_types::Register::classes) {
         logger.debug("Image for custom type: {}::{} {}", itr->namespaze, itr->name, fmt::ptr(itr->image) );
     }

--- a/src/test_small.cpp
+++ b/src/test_small.cpp
@@ -1,24 +1,28 @@
 #ifdef LOCAL_TEST
 #include "macros.hpp"
 
-DECLARE_CLASS(Custom, Tester, "System", "Object", sizeof(Il2CppObject),
+DECLARE_CLASS(Custom, Tester, "System", "Object", sizeof(Il2CppObject)) {
     DECLARE_STATIC_FIELD(int, x);
     DECLARE_INSTANCE_FIELD_DEFAULT(float, z, 3.0f);
     DECLARE_INSTANCE_METHOD(bool, test, int arg1, int arg2);
     // bool test(int arg1, int arg2);
-)
+};
 DEFINE_TYPE(Custom, Tester);
 
 bool Custom::Tester::test([[maybe_unused]] int arg1, [[maybe_unused]] int arg2) {
     return false;
 }
 
-DECLARE_CLASS_CUSTOM(Custom, Test2, Custom::Tester,
+DECLARE_CLASS_CUSTOM(Custom, Test2, Custom::Tester) {
     DECLARE_INSTANCE_FIELD(int, y);
-)
+};
 DEFINE_TYPE(Custom, Test2);
 
 void testStuff() {
     custom_types::Register::AutoRegister();
+    static_assert(sizeof(Custom::Tester) == Custom::Tester::__IL2CPP_REFERENCE_TYPE_SIZE);
+    static_assert(sizeof(Custom::Tester) == sizeof(Il2CppObject) + sizeof(float));
+    static_assert(sizeof(Custom::Test2) == Custom::Test2::__IL2CPP_REFERENCE_TYPE_SIZE);
+    static_assert(sizeof(Custom::Test2) == sizeof(Custom::Tester) + sizeof(int));
 }
 #endif


### PR DESCRIPTION
Allows better auto formatting and cleaner interface lists. Tested fairly extensively in a real mod.